### PR TITLE
Add a test case checking context precedence

### DIFF
--- a/specs/sections.yml
+++ b/specs/sections.yml
@@ -47,6 +47,12 @@ tests:
     template: '"{{#context}}Hi {{name}}.{{/context}}"'
     expected: '"Hi Joe."'
 
+  - name: Context Precedence
+    desc: The context stack should be walked from top to bottom.
+    data: { entree: 'chicken', vegetarian: { entree: 'rice and beans' } }
+    template: '{{entree}} : {{#vegetarian}}{{entree}}{{/vegetarian}}'
+    expected: 'chicken : rice and beans'
+
   - name: Deeply Nested Contexts
     desc: All elements on the context stack should be accessible.
     data:


### PR DESCRIPTION
It doesn't look like the spec includes a test case checking that items higher in the context stack should take precedence -- especially a test case checking this in isolation.  Here is one.
