### PR TITLE
Add a test for not interpolating rendered section output

### DIFF
--- a/specs/sections.yml
+++ b/specs/sections.yml
@@ -41,6 +41,12 @@ tests:
     template: '"{{#boolean}}This should not be rendered.{{/boolean}}"'
     expected: '""'
 
+  - name: Non-interpolation
+    desc: Rendered section output should not be interpolated.
+    data: { section: true, template: '{{planet}}', planet: 'Earth' }
+    template: '{{#section}}{{template}}{{/section}}: {{planet}}'
+    expected: '{{planet}}: Earth'
+
   - name: Context
     desc: Objects and hashes should be pushed onto the context stack.
     data: { context: { name: 'Joe' } }


### PR DESCRIPTION
In contrast to lambda return values, the output of rendering a section should not be parsed.  I think a test case would be helpful here to draw a distinction with that behavior.  Test case included.

The attached test case would also clarify that nested sections should be evaluated "outside-in" rather than "inside-out."  For example--

```
data: { outer: true, inner: true, template: '{{planet}}', planet: 'Earth'}
template: '{{#outer}}{{planet}} : Interpolate? {{#inner}}{{template}}{{/inner}}{{/outer}}'
```
