### PR TITLE
Add a test that interpolated content should not be re-interpolated

### DIFF
--- a/specs/interpolation.yml
+++ b/specs/interpolation.yml
@@ -34,6 +34,12 @@ tests:
     expected: |
       Hello, world!
 
+  - name: No Re-interpolation
+    desc: Interpolated tag output should not be re-interpolated.
+    data: { template: '{{planet}}', planet: 'Earth' }
+    template: '{{template}}: {{planet}}'
+    expected: '{{planet}}: Earth'
+
   - name: HTML Escaping
     desc: Basic interpolation should be HTML escaped.
     data: { forbidden: '& " < >' }


### PR DESCRIPTION
This is basically the same as the test case of issue #32, but for basic (non-section) tags.
