### PR TITLE
Add a test not to interpret strings as lists

### DIFF
--- a/specs/sections.yml
+++ b/specs/sections.yml
@@ -98,6 +98,12 @@ tests:
     template: '"{{#list}}Yay lists!{{/list}}"'
     expected: '""'
 
+  - name: Strings Not Lists
+    desc: Strings should not be interpreted as list types.
+    data: { section: '123' }
+    template: '"{{#section}}foo{{/section}}"'
+    expected: '"foo"'
+
   - name: Doubled
     desc: Multiple sections per template should be permitted.
     data: { bool: true, two: 'second' }


### PR DESCRIPTION
In Python, for example (as in many other languages undoubtedly), strings are sequence types that share many of the same properties as lists and other iterator types:

  http://docs.python.org/library/stdtypes.html#sequence-types-str-unicode-list-tuple-bytearray-buffer-xrange

It would be good to add a test for this.  One does not seem to exist yet in the spec (incidental or not).
