### PR TITLE
Add more tests for lambdas used in sections

### DIFF
--- a/specs/~lambdas.yml
+++ b/specs/~lambdas.yml
@@ -119,6 +119,17 @@ tests:
     template: "<{{#lambdas}}planet{{/lambdas}}>"
     expected: "<~Earth~#Earth#>"
 
+  - name: Section - Mixed Lists
+    desc: Sections should permit mixed lists of lambdas and non-lambdas.
+    data:
+      planet: "Earth"
+      lambdas:
+        - !code
+          python:  'lambda text: "~{{%s}}~" % text'
+        - 1
+    template: "<{{#lambdas}}planet{{/lambdas}}>"
+    expected: "<~Earth~planet>"
+
   - name: Section - Context Stack
     desc: |
       Lambdas used for sections should not be pushed onto the context


### PR DESCRIPTION
Here are a few tests for increased coverage of the rules governing lambdas in the context of sections.

The Python implementation missed two of these test cases (the first and second) even though it passed all other tests involving lambdas or the single dot.
