### PR TITLE
Add a test that dotted name resolution should make forward-only progress

### DIFF
--- a/specs/interpolation.yml
+++ b/specs/interpolation.yml
@@ -173,9 +173,11 @@ tests:
 
   - name: Dotted Names - Context Precedence
     desc: Dotted names should be resolved against former resolutions.
-    data: { a: { b: 'b found: ERROR' }, c: { a: 'b not found'} }
-    template: '{{#c}}"{{a}}" : "{{a.b}}"{{/c}}'
-    expected: '"b not found" : ""'
+    data:
+      a: { b: { } }
+      b: { c: 'ERROR' }
+    template: '{{#a}}{{b.c}}{{/a}}'
+    expected: ''
 
   # Whitespace Sensitivity
 


### PR DESCRIPTION
This test case tests that successive portions of dotted names should be resolved against former resolutions (i.e. forward-only progress).

I don't think a test like this currently exists.  It seems like an important case.
