### PR TITLE
Spec tests for non-alphabetical partial names

### DIFF
--- a/specs/partials.yml
+++ b/specs/partials.yml
@@ -107,3 +107,40 @@ tests:
     template: "|{{> partial }}|"
     partials: { partial: "[]" }
     expected: '|[]|'
+
+  # Partial name parsing
+  - name: Partial names: numbers
+    desc: Partial names can include numbers
+    data: { text: 'content' }
+    template: '"{{>partial5name}}"'
+    partials: { 'partial5name': '*{{text}}*' }
+    expected: '"*content*"'
+
+  - name: Partial names: hyphen
+    desc: Partial names can include hyphens
+    data: { text: 'content' }
+    template: '"{{>partial-name}}"'
+    partials: { 'partial-name': '*{{text}}*' }
+    expected: '"*content*"'
+
+  - name: Partial names: underscore
+    desc: Partial names can include underscores
+    data: { text: 'content' }
+    template: '"{{>partial_name}}"'
+    partials: { 'partial_name': '*{{text}}*' }
+    expected: '"*content*"'
+
+  - name: Partial names: colon
+    desc: Partial names can include colons
+    data: { text: 'content' }
+    template: '"{{>partial:name}}"'
+    partials: { 'partial:name': '*{{text}}*' }
+    expected: '"*content*"'
+
+  - name: Partial names: caret
+    desc: Partial names can include carets
+    data: { text: 'content' }
+    template: '"{{>partial^name}}"'
+    partials: { 'partial^name': '*{{text}}*' }
+    expected: '"*content*"'
+


### PR DESCRIPTION
from specs/partials.yml: "The tag's content MUST be a non-whitespace character sequence NOT containing the current closing delimiter."

I added spec tests for partial names that include a number, hyphen, underscore, period, forward slash, colon, tilde, caret.
