### PR TITLE
Try to clarify legal names

### DIFF
--- a/specs/interpolation.yml
+++ b/specs/interpolation.yml
@@ -2,7 +2,8 @@ overview: |
   Interpolation tags are used to integrate dynamic content into the template.
 
   The tag's content MUST be a non-whitespace character sequence NOT containing
-  the current closing delimiter.
+  the current closing delimiter. Leading and trailing whitespace are permitted
+  between the opening and closing delimiters.
 
   This tag's content names the data to replace the tag.  A single period (`.`)
   indicates that the item currently sitting atop the context stack should be


### PR DESCRIPTION
The current definition:

> The tag's content MUST be a non-whitespace character sequence NOT
> containing the current closing delimiter.

That would imply that `{{content}}` is legal, but `{{ content }}` is
not legal.

However, later tests state “Superfluous in-tag whitespace should be
ignored.” and include tests for `{{ string }}`.

This change attempts to make that clearer and consistent everywhere.

Possibly a BNF or similar grammar would be helpful?
