### PR TITLE
Test for rendering nested partials.

### DIFF
--- a/specs/partials.yml
+++ b/specs/partials.yml
@@ -42,6 +42,13 @@ tests:
     partials: { node: '{{content}}<{{#nodes}}{{>node}}{{/nodes}}>' }
     expected: 'X<Y<>>'
 
+  - name: Nested
+    desc: The greater-than operator should work from within partials.
+    data: { a: "hello", b: "world" }
+    template: '{{>outer}}'
+    partials: { outer: '*{{a}} {{>inner}}*', inner: '{{b}}!' }
+    expected: '*hello world!*'
+
   # Whitespace Sensitivity
 
   - name: Surrounding Whitespace


### PR DESCRIPTION
I'm assuming this is expected behavior due to already having a test for recursive partials, and that the ruby implementation handles this behavior (from my limited testing).
