### PR TITLE
Add spec for leading dot

### DIFF
--- a/specs/interpolation.yml
+++ b/specs/interpolation.yml
@@ -171,6 +171,15 @@ tests:
     template: '"{{#a}}{{b.c.d.e.name}}{{/a}}" == "Phil"'
     expected: '"Phil" == "Phil"'
 
+  - name: Dotted Names - Leading Dot
+    desc: A leading dot should force resolution inside the current scope.
+    data:
+      a: { }
+      b: { name: 'Name' }
+      name: 'Fail'
+    template: '{{#a}}{{.name}}{{/a}}{{#b}}{{.name}}{{/b}}'
+    expected: 'Name'
+
   - name: Dotted Names - Context Precedence
     desc: Dotted names should be resolved against former resolutions.
     data:


### PR DESCRIPTION
Fixes https://github.com/mustache/spec/issues/52

The feature proposed there is extremely useful. It’s the only way to DRY out templates which deal with recursive data (like here: <http://stackoverflow.com/a/13592747/2816199>). The new syntax should also allow more radical perf optimizations.