### PR TITLE
Enhance the Standalone Indentation test

### DIFF
--- a/specs/partials.yml
+++ b/specs/partials.yml
@@ -80,7 +80,7 @@ tests:
     expected: ">\n  >\n  >"
 
   - name: Standalone Indentation
-    desc: Each line of the partial should be indented before rendering.
+    desc: Each new line of the partial should be indented before rendering.
     data: { content: "<\n->" }
     template: |
       \
@@ -89,13 +89,14 @@ tests:
     partials:
       partial: |
         |
-        {{{content}}}
+        {{{content}}}a b{{{content}}}c
         |
     expected: |
       \
        |
        <
-      ->
+      ->a b<
+      ->c
        |
       /
 


### PR DESCRIPTION
The indentation should only be applied at the start of a line.