### PR TITLE
Remove inaccurate documentation about __tag__ in JSON specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,6 @@ best-effort basis.
 These should be identical to the YAML specifications, but if you find the need
 to regenerate them, they can be trivially rebuilt by invoking `rake build`.
 
-It is also worth noting that some specifications (notably, the lambda module)
-rely on YAML "tags" to denote special types of data (e.g. source code).  Since
-JSON offers no way to denote this, a special key ("`__tag__`") is injected
-with the name of the tag as its value.  See `TESTING.md` for more information
-about handling tagged data.
-
 Optional Modules
 ----------------
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -14,9 +14,9 @@ In general, the process for each `.yml` file is as follows:
   2. If your implementation will not support lambdas, feel free to skip over
      the optional '~lambdas.yml' file.
 
-  2.1. If your implementation will support lambdas, ensure that each member of
-       'data' tagged with '!code' is properly processed into a language-
-       specific lambda reference.
+  2.1. If your implementation will support lambdas, ensure that the `lambda`
+       member of `data` (tagged with `!code`) is properly processed into a
+       language-specific lambda reference.
 
       *   e.g. Given this YAML data hash:
 
@@ -30,9 +30,6 @@ In general, the process for each `.yml` file is as follows:
       *   If your implementation language does not currently have lambda
           examples in the spec, feel free to implement them and send a pull
           request.
-
-      *   The JSON version of the spec represents these tagged values as a hash
-          with a '`__tag__`' key of 'code'.
 
   3. Render the template (stored in the 'template' key) with the given 'data'
      hash.

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,38 +6,38 @@ In general, the process for each `.yml` file is as follows:
 
 1. Use a YAML parser to load the file.
 
-2. For each test in the 'tests' array:
+2. For each test in the `tests` array:
 
-  1. Ensure that each element of the 'partials' hash (if it exists) is
-     stored in a place where the interpreter will look for it.
+   1. Ensure that each element of the `partials` hash (if it exists) is
+      stored in a place where the interpreter will look for it.
 
-  2. If your implementation will not support lambdas, feel free to skip over
-     the optional '~lambdas.yml' file.
+   2. If your implementation will not support lambdas, feel free to skip over
+      the optional `~lambdas.yml` file.
 
-  2.1. If your implementation will support lambdas, ensure that the `lambda`
-       member of `data` (tagged with `!code`) is properly processed into a
-       language-specific lambda reference.
+3. If your implementation will support lambdas, ensure that the `lambda`
+   member of `data` (tagged with `!code`) is properly processed into a
+   language-specific lambda reference.
 
-      *   e.g. Given this YAML data hash:
+   * e.g. Given this YAML data hash:
 
-          `{ x: !code { ruby: 'proc { "x" }', perl: 'sub { "x" }' } }`
+     `{ x: !code { ruby: 'proc { "x" }', perl: 'sub { "x" }' } }`
 
-          a Ruby-based Mustache implementation would process it such that it
-          was equivalent to this Ruby hash:
+     a Ruby-based Mustache implementation would process it such that it
+     was equivalent to this Ruby hash:
 
-          `{ 'x' => proc { "x" } }`
+     `{ 'x' => proc { "x" } }`
 
-      *   If your implementation language does not currently have lambda
-          examples in the spec, feel free to implement them and send a pull
-          request.
+   * If your implementation language does not currently have lambda
+     examples in the spec, feel free to implement them and send a pull
+     request.
 
-  3. Render the template (stored in the 'template' key) with the given 'data'
-     hash.
+4. Render the template (stored in the `template` key) with the given `data`
+   hash.
 
-  4. Compare the results of your rendering against the 'expected' value; any
-     differences should be reported, along with any useful debugging
-     information.
+5. Compare the results of your rendering against the `expected` value; any
+   differences should be reported, along with any useful debugging
+   information.
 
-     *  Of note, the 'desc' key contains a rough one-line description of the
-        behavior being tested -- this is most useful in conjunction with the
-        file name and test 'name'.
+   * Of note, the `desc` key contains a rough one-line description of the
+     behavior being tested -- this is most useful in conjunction with the
+     file name and test `name`.


### PR DESCRIPTION
There is no special `__tag__` key in the JSON files. Instead, it
is the `lambda` entry which is significant. While Ruby may depend
on the YAML `!code` tag, that doesn't make it into the JSON format.