### PR TITLE
Specify interpolation behavior for implicit iterator

### DIFF
--- a/specs/interpolation.json
+++ b/specs/interpolation.json
@@ -245,6 +245,41 @@
       "expected": ""
     },
     {
+      "name": "Implicit Iterators - Basic Interpolation",
+      "desc": "Unadorned tags should interpolate content into the template.",
+      "data": "world",
+      "template": "Hello, {{.}}!\n",
+      "expected": "Hello, world!\n"
+    },
+    {
+      "name": "Implicit Iterators - HTML Escaping",
+      "desc": "Basic interpolation should be HTML escaped.",
+      "data": "& \" < >",
+      "template": "These characters should be HTML escaped: {{.}}\n",
+      "expected": "These characters should be HTML escaped: &amp; &quot; &lt; &gt;\n"
+    },
+    {
+      "name": "Implicit Iterators - Triple Mustache",
+      "desc": "Triple mustaches should interpolate without HTML escaping.",
+      "data": "& \" < >",
+      "template": "These characters should not be HTML escaped: {{{.}}}\n",
+      "expected": "These characters should not be HTML escaped: & \" < >\n"
+    },
+    {
+      "name": "Implicit Iterators - Ampersand",
+      "desc": "Ampersand should interpolate without HTML escaping.",
+      "data": "& \" < >",
+      "template": "These characters should not be HTML escaped: {{&.}}\n",
+      "expected": "These characters should not be HTML escaped: & \" < >\n"
+    },
+    {
+      "name": "Implicit Iterators - Basic Integer Interpolation",
+      "desc": "Integers should interpolate seamlessly.",
+      "data": 85,
+      "template": "\"{{.}} miles an hour!\"",
+      "expected": "\"85 miles an hour!\""
+    },
+    {
       "name": "Interpolation - Surrounding Whitespace",
       "desc": "Interpolation should not alter surrounding whitespace.",
       "data": {

--- a/specs/interpolation.yml
+++ b/specs/interpolation.yml
@@ -179,6 +179,46 @@ tests:
     template: '{{#a}}{{b.c}}{{/a}}'
     expected: ''
 
+  # Implicit Iterators
+
+  - name: Implicit Iterators - Basic Interpolation
+    desc: Unadorned tags should interpolate content into the template.
+    data: "world"
+    template: |
+      Hello, {{.}}!
+    expected: |
+      Hello, world!
+
+  - name: Implicit Iterators - HTML Escaping
+    desc: Basic interpolation should be HTML escaped.
+    data: '& " < >'
+    template: |
+      These characters should be HTML escaped: {{.}}
+    expected: |
+      These characters should be HTML escaped: &amp; &quot; &lt; &gt;
+
+  - name: Implicit Iterators - Triple Mustache
+    desc: Triple mustaches should interpolate without HTML escaping.
+    data: '& " < >'
+    template: |
+      These characters should not be HTML escaped: {{{.}}}
+    expected: |
+      These characters should not be HTML escaped: & " < >
+
+  - name: Implicit Iterators - Ampersand
+    desc: Ampersand should interpolate without HTML escaping.
+    data: '& " < >'
+    template: |
+      These characters should not be HTML escaped: {{&.}}
+    expected: |
+      These characters should not be HTML escaped: & " < >
+
+  - name: Implicit Iterators - Basic Integer Interpolation
+    desc: Integers should interpolate seamlessly.
+    data: 85
+    template: '"{{.}} miles an hour!"'
+    expected: '"85 miles an hour!"'
+
   # Whitespace Sensitivity
 
   - name: Interpolation - Surrounding Whitespace


### PR DESCRIPTION
My follow-up on #82. Although I don't think my suggested changes would be very controversial, there is some slight potential for breakage here. While my own implementation passes the new tests without modifications, I imagine that some implementations might support the implicit iterator only within a section. I'm open to discussion.