### PR TITLE
Specify substituted block scope resolution

### DIFF
--- a/specs/~inheritance.json
+++ b/specs/~inheritance.json
@@ -230,6 +230,21 @@
         "parent": "{{$foo}}default content{{/foo}}"
       },
       "expected": "default content"
+    },
+    {
+      "name": "Block scope",
+      "desc": "Scope of a substituted block is evaluated in the context of the parent template",
+      "data": {
+        "fruit": "apples",
+        "nested": {
+          "fruit": "bananas"
+        }
+      },
+      "template": "{{<parent}}{{$block}}I say {{fruit}}.{{/block}}{{/parent}}",
+      "partials": {
+        "parent": "{{#nested}}{{$block}}You say {{fruit}}.{{/block}}{{/nested}}"
+      },
+      "expected": "I say bananas."
     }
   ]
 }

--- a/specs/~inheritance.yml
+++ b/specs/~inheritance.yml
@@ -224,3 +224,14 @@ tests:
     partials:
       parent: "{{$foo}}default content{{/foo}}"
     expected: default content
+
+  - name: Block scope
+    desc: Scope of a substituted block is evaluated in the context of the parent template
+    data:
+      fruit: apples
+      nested:
+        fruit: bananas
+    template: "{{<parent}}{{$block}}I say {{fruit}}.{{/block}}{{/parent}}"
+    partials:
+      parent: "{{#nested}}{{$block}}You say {{fruit}}.{{/block}}{{/nested}}"
+    expected: I say bananas.


### PR DESCRIPTION
This is my first follow-up on #125. I planned this addition already in April, but the work was delayed until now due to other projects intervening.

The diff, which is very small, probably speaks for itself. I wrote this spec after completing my own implementation of template inheritance, and I didn't need to change my implementation in order to pass the new spec. If I understood correctly, at least Mustache.php by @bobthecow and Ocaml-Mustache by @gasche already implement this spec, too. To me this seems the most intuitive interpretation of scope in a substituted block, so I hope it will be fairly uncontroversial.