### PR TITLE
Additional inheritance specs for block reindentation

### DIFF
--- a/specs/~inheritance.json
+++ b/specs/~inheritance.json
@@ -245,6 +245,62 @@
         "parent": "{{#nested}}{{$block}}You say {{fruit}}.{{/block}}{{/nested}}"
       },
       "expected": "I say bananas."
+    },
+    {
+      "name": "Standalone parent",
+      "desc": "A parent's opening and closing tags need not be on separate lines in order to be standalone",
+      "data": {
+      },
+      "template": "Hi,\n  {{<parent}}{{/parent}}\n",
+      "partials": {
+        "parent": "one\ntwo\n"
+      },
+      "expected": "Hi,\n  one\n  two\n"
+    },
+    {
+      "name": "Standalone block",
+      "desc": "A block's opening and closing tags need not be on separate lines in order to be standalone",
+      "data": {
+      },
+      "template": "{{<parent}}{{$block}}\none\ntwo{{/block}}\n{{/parent}}\n",
+      "partials": {
+        "parent": "Hi,\n  {{$block}}{{/block}}\n"
+      },
+      "expected": "Hi,\n  one\n  two\n"
+    },
+    {
+      "name": "Block reindentation",
+      "desc": "Block indentation is removed at the site of definition and added at the site of expansion",
+      "data": {
+      },
+      "template": "{{<parent}}{{$block}}\n    one\n    two\n{{/block}}{{/parent}}\n",
+      "partials": {
+        "parent": "Hi,\n  {{$block}}\n  {{/block}}\n"
+      },
+      "expected": "Hi,\n  one\n  two\n"
+    },
+    {
+      "name": "Intrinsic indentation",
+      "desc": "When the block opening tag is standalone, indentation is determined by default content",
+      "data": {
+      },
+      "template": "{{<parent}}{{$block}}\none\ntwo\n{{/block}}{{/parent}}\n",
+      "partials": {
+        "parent": "Hi,\n{{$block}}\n  default\n{{/block}}\n"
+      },
+      "expected": "Hi,\n  one\n  two\n"
+    },
+    {
+      "name": "Nested block reindentation",
+      "desc": "Nested blocks are reindented relative to the surrounding block",
+      "data": {
+      },
+      "template": "{{<parent}}{{$nested}}\nthree\n{{/nested}}{{/parent}}\n",
+      "partials": {
+        "parent": "{{<grandparent}}{{$block}}\n  one\n  {{$nested}}\n    two\n  {{/nested}}\n{{/block}}{{/grandparent}}\n",
+        "grandparent": "{{$block}}default{{/block}}"
+      },
+      "expected": "one\n  three\n"
     }
   ]
 }

--- a/specs/~inheritance.yml
+++ b/specs/~inheritance.yml
@@ -304,3 +304,23 @@ tests:
       Hi,
         one
         two
+
+  - name: Nested block reindentation
+    desc: Nested blocks are reindented relative to the surrounding block
+    data: {}
+    template: |
+      {{<parent}}{{$nested}}
+      three
+      {{/nested}}{{/parent}}
+    partials:
+      parent: |
+        {{<grandparent}}{{$block}}
+          one
+          {{$nested}}
+            two
+          {{/nested}}
+        {{/block}}{{/grandparent}}
+      grandparent: "{{$block}}default{{/block}}"
+    expected: |
+      one
+        three

--- a/specs/~inheritance.yml
+++ b/specs/~inheritance.yml
@@ -235,3 +235,72 @@ tests:
     partials:
       parent: "{{#nested}}{{$block}}You say {{fruit}}.{{/block}}{{/nested}}"
     expected: I say bananas.
+
+  - name: Standalone parent
+    desc: A parent's opening and closing tags need not be on separate lines in order to be standalone
+    data: {}
+    template: |
+      Hi,
+        {{<parent}}{{/parent}}
+    partials:
+      parent: |
+        one
+        two
+    expected: |
+      Hi,
+        one
+        two
+
+  - name: Standalone block
+    desc: A block's opening and closing tags need not be on separate lines in order to be standalone
+    data: {}
+    template: |
+      {{<parent}}{{$block}}
+      one
+      two{{/block}}
+      {{/parent}}
+    partials:
+      parent: |
+        Hi,
+          {{$block}}{{/block}}
+    expected: |
+      Hi,
+        one
+        two
+
+  - name: Block reindentation
+    desc: Block indentation is removed at the site of definition and added at the site of expansion
+    data: {}
+    template: |
+      {{<parent}}{{$block}}
+          one
+          two
+      {{/block}}{{/parent}}
+    partials:
+      parent: |
+        Hi,
+          {{$block}}
+          {{/block}}
+    expected: |
+      Hi,
+        one
+        two
+
+  - name: Intrinsic indentation
+    desc: When the block opening tag is standalone, indentation is determined by default content
+    data: {}
+    template: |
+      {{<parent}}{{$block}}
+      one
+      two
+      {{/block}}{{/parent}}
+    partials:
+      parent: |
+        Hi,
+        {{$block}}
+          default
+        {{/block}}
+    expected: |
+      Hi,
+        one
+        two


### PR DESCRIPTION
When we pass a block to a parent, we would ideally expect it to "magically" adjust its indentation.

*template.mustache*

```
{{<parent}}
        {{$block}}
        Hello
        {{/block}}
{{/parent}}
```

*parent.mustache*

```
I say,
  {{$block}}
  Hi there!
  {{/block}}
```

*output*

```
I say,
  Hello
```

*Try the above example in the [playground](https://jgonggrijp.gitlab.io/wontache/playground.html) by pasting the following code:*

```json
{"data":{"text":"null"},"templates":[{"name":"template","text":"{{<parent}}\n        {{$block}}\n        Hello\n        {{/block}}\n{{/parent}}"},{"name":"parent","text":"I say,\n  {{$block}}\n  Hi there!\n  {{/block}}"}]}
```

I wrote an extremely long post in #130 on how this might be approached, inviting for a discussion. However, I realized that the post was so long that most people simply might not find the time (or patience or courage) to read it. I hope this PR will be an acceptable alternative to those people, being more concrete and containing substantially less text.

For a detailed rationale behind the specs that I'm proposing here, please refer to #130. The short version is that I applied the following rules. I was able to fully conform my own implementation to these specs. I needed to grow the code size by only seven lines on balance, though there were some subtleties that I'll mention in code comments below.

0. **Standalone tags** (pre-existing rule). Individual block and parent tags should not introduce blank lines in the output when they clear on both delimiters.
1. **Standalone pairs.** The *pair* of a parent tag and its matching end section tag *as a whole* is standalone if the opening tag clears at the start and the closing tag clears at the end. This notion of a standalone pair is also applicable to parameter blocks, because these are sites of template expansion, too. It does not apply to argument blocks, because those are not template expansion sites.
2. **Intrinsic indentation.** If the opening tag of an argument block or a standalone parameter block clears at the end, then the intrinsic indentation of the block is the whitespace at the start of the first line after the opening block tag. In all remaining cases, the intrinsic indentation of a block is the empty string.
3. **Deindentation at block definition time.** The intrinsic indentation of a block definition is removed from each of its lines before anything else happens with its contents.
4. **Indentation at template expansion sites** (generalization of existing standalone partial indentation rule). The indentation of a partial tag, parent pair or parameter block pair is determined as follows. If it is a block with intrinsic indentation, then the intrinsic indentation is used. Otherwise, if the tag or pair is standalone, then the indentation of the single tag or the pair's opening tag is used. In all remaining cases, the empty string is used. The indentation thus determined is added to each line of whichever (external) template or block ends up being expanded in the position of the tag or pair, before that template or block is rendered.

Merging this PR would close #130.

CC to all people I CC'ed in #130: @gasche @softmoth @adam-fowler @Danappelxx @pvande @splumhoff @bobthecow @sayrer @spullara .