### PR TITLE
add test: comment content colliding with variable

### DIFF
--- a/specs/comments.json
+++ b/specs/comments.json
@@ -89,6 +89,18 @@
       },
       "template": "12345 {{! Comment Block! }} 67890",
       "expected": "12345  67890"
+    },
+    {
+      "name": "Variable Name Collision",
+      "desc": "Comments must never render, even if variable with same name exists.",
+      "data": {
+        "! comment": 1,
+        "! comment ": 2,
+        "!comment": 3,
+        "comment": 4
+      },
+      "template": "comments never show: >{{! comment }}<",
+      "expected": "comments never show: ><"
     }
   ]
 }

--- a/specs/comments.yml
+++ b/specs/comments.yml
@@ -101,3 +101,9 @@ tests:
     data: { }
     template: '12345 {{! Comment Block! }} 67890'
     expected: '12345  67890'
+
+  - name: Variable Name Collision
+    desc: Comments must never render, even if variable with same name exists.
+    data: { '! comment': 1, '! comment ': 2, '!comment': 3, 'comment': 4}
+    template: 'comments never show: >{{! comment }}<'
+    expected: 'comments never show: ><'


### PR DESCRIPTION
Currently, an implementation treating comments as undefined variables
successfully passes all tests, because both undefined variables and
comments render to empty string.

This clarifies the behavior: A comment MUST NOT render into anything,
under any circumstances. This includes the case where a variable with
the same name as the comment content is defined.

The test data is designed in a way to trigger any possible name
collision, including whitespaces, a leading exclamation mark (!).

Closes #136 