### PR TITLE
Add TaggedMap to permitted_classes to accomodate Psych with Ruby >= 3.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,10 @@ namespace :build do
 
       File.open(json_file, 'w') do |file|
         warning = {:__ATTN__ => note}
-        doc = YAML.load_file(filename)
+        doc = YAML.load_file(
+            filename,
+            permitted_classes: [TaggedMap]
+        )
         file << JSON.pretty_generate(warning.merge(doc)) << "\n"
       end
     end


### PR DESCRIPTION
While reviewing #176, I wanted to regenerate the JSON files to double-check the updates in there. This initially failed, because I upgraded to Ruby 3.2 in the meanwhile and the Psych dependency is much stricter now.

By way of review, I would appreciate a confirmation that someone with Ruby < 3.1 is also still able to generate the JSON after these changes.