### PR TITLE
Fine-tune GitHub's language detection for the repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+specs/**/*.yml linguist-detectable


### PR DESCRIPTION
Advertise `*.yml` files in `specs/` directory as "source" code. According to README:
> The specification is developed as a series of YAML files, under the specs directory.

Correctly identifying main language of the repo on GitHub may help attracting more contributors.

|Before|After|
|---|---|
|![image](https://github.com/mustache/spec/assets/25753618/b21786f7-6386-4b78-a0ba-e493d0b2419c)|![image](https://github.com/mustache/spec/assets/25753618/9f72f139-309e-4c85-b139-515fe45958ed)|
|![image](https://github.com/mustache/spec/assets/25753618/19d8949d-ad90-4339-a94e-aa202d0a0de4)|![image](https://github.com/mustache/spec/assets/25753618/8a8b1d3d-c788-482f-8126-8eb567fa0ae2)|