### PR TITLE
Add missing test to JSON conversion

### DIFF
--- a/specs/interpolation.json
+++ b/specs/interpolation.json
@@ -20,6 +20,16 @@
       "expected": "Hello, world!\n"
     },
     {
+      "name": "No Re-interpolation",
+      "desc": "Interpolated tag output should not be re-interpolated.",
+      "data": {
+        "template": "{{planet}}",
+        "planet": "Earth"
+      },
+      "template": "{{template}}: {{planet}}",
+      "expected": "{{planet}}: Earth"
+    },
+    {
       "name": "HTML Escaping",
       "desc": "Basic interpolation should be HTML escaped.",
       "data": {


### PR DESCRIPTION
I was regenerating the JSON because of #180. To my surprise, this test was added to the JSON as well. It seems to have been missing ever since the corresponding test in the YAML was added in 2012. I have no idea how it escaped every time, for example also in #113 and #119.

I am not waiting for a review, because this is just bringing the JSON up to date with the YAML. However, I am still submitting a pull request for the sake of openness.