### PR TITLE
Implement lambdas for MATLAB

### DIFF
--- a/specs/~lambdas.json
+++ b/specs/~lambdas.json
@@ -90,7 +90,7 @@
           "pwsh": "if (($null -eq $script:calls) -or ($script:calls -ge 3)){$script:calls=0}; ++$script:calls; $script:calls",
           "go": "func() func() int { g := 0; return func() int { g++; return g } }()",
           "erlang": "fun() -> G=case get(g) of undefined -> 1; _G -> _G end, put(g, G+1), G end.",
-          "matlab": "@()feval(@(x,c)c, evalc('setenv(''COUNT'', string(lookup(dictionary(NaN,1,3,1), str2double(getenv(''COUNT'')), FallbackValue=str2double(getenv(''COUNT''))+1)))'), str2double(getenv('COUNT')))"
+          "matlab": "@() feval(@(~) getappdata(0, 'calls'), evalc('setappdata(0, ''calls'', mod(sum(getappdata(0, ''calls'')), 3) + 1)'))"
         }
       },
       "template": "{{lambda}} == {{{lambda}}} == {{lambda}}",
@@ -137,7 +137,7 @@
           "pwsh": "if ($args[0] -eq \"{{x}}\") {\"yes\"} else {\"no\"}",
           "go": "func(text string) string { if text == \"{{x}}\" { return \"yes\" } else { return \"no\" } }",
           "erlang": "fun(\"{{x}}\") -> \"yes\"; (_) -> \"no\" end.",
-          "matlab": "@(text)lookup(dictionary(true, \"yes\"), text==\"{{x}}\", FallbackValue=\"no\")"
+          "matlab": "@(text) replace(string(text == \"{{x}}\"), [\"false\", \"true\"], [\"no\", \"yes\"])"
         }
       },
       "template": "<{{#lambda}}{{x}}{{/lambda}}>",
@@ -208,7 +208,7 @@
           "pwsh": "\"__$($args[0])__\"",
           "go": "func(text string) string { return \"__\" + text + \"__\" }",
           "erlang": "fun(Text) -> \"__\" ++ Text ++ \"__\" end.",
-          "matlab": "@(text)\"__\" + text + \"__\""
+          "matlab": "@(text) \"__\" + text + \"__\""
         }
       },
       "template": "{{#lambda}}FILE{{/lambda}} != {{#lambda}}LINE{{/lambda}}",
@@ -232,7 +232,7 @@
           "pwsh": "$false",
           "go": "func(text string) bool { return false }",
           "erlang": "fun(_) -> false end.",
-          "matlab": "@() false"
+          "matlab": "@(~) false"
         }
       },
       "template": "<{{^lambda}}{{static}}{{/lambda}}>",

--- a/specs/~lambdas.json
+++ b/specs/~lambdas.json
@@ -90,7 +90,7 @@
           "pwsh": "if (($null -eq $script:calls) -or ($script:calls -ge 3)){$script:calls=0}; ++$script:calls; $script:calls",
           "go": "func() func() int { g := 0; return func() int { g++; return g } }()",
           "erlang": "fun() -> G=case get(g) of undefined -> 1; _G -> _G end, put(g, G+1), G end.",
-          "matlab": "@() feval(@(~) getappdata(0, 'calls'), evalc('setappdata(0, ''calls'', mod(sum(getappdata(0, ''calls'')), 3) + 1)'))"
+          "matlab": "@() feval(@(~) getappdata(0, \"calls\"), evalc(\"setappdata(0, \"\"calls\"\", mod(sum(getappdata(0, \"\"calls\"\")), 3) + 1)\"))"
         }
       },
       "template": "{{lambda}} == {{{lambda}}} == {{lambda}}",

--- a/specs/~lambdas.json
+++ b/specs/~lambdas.json
@@ -18,7 +18,8 @@
           "lisp": "(lambda () \"world\")",
           "pwsh": "\"world\"",
           "go": "func() string { return \"world\" }",
-          "erlang": "fun() -> \"world\" end."
+          "erlang": "fun() -> \"world\" end.",
+          "matlab": "@() \"world\""
         }
       },
       "template": "Hello, {{lambda}}!",
@@ -41,7 +42,8 @@
           "lisp": "(lambda () \"{{planet}}\")",
           "pwsh": "\"{{planet}}\"",
           "go": "func() string { return \"{{planet}}\" }",
-          "erlang": "fun() -> \"{{planet}}\" end."
+          "erlang": "fun() -> \"{{planet}}\" end.",
+          "matlab": "@() \"{{planet}}\""
         }
       },
       "template": "Hello, {{lambda}}!",
@@ -64,7 +66,8 @@
           "lisp": "(lambda () \"|planet| => {{planet}}\")",
           "pwsh": "\"|planet| => {{planet}}\"",
           "go": "func() string { return \"|planet| => {{planet}}\" }",
-          "erlang": "fun() -> \"|planet| => {{planet}}\" end."
+          "erlang": "fun() -> \"|planet| => {{planet}}\" end.",
+          "matlab": "@() \"|planet| => {{planet}}\""
         }
       },
       "template": "{{= | | =}}\nHello, (|&lambda|)!",
@@ -86,7 +89,8 @@
           "lisp": "(let ((g 0)) (lambda () (incf g)))",
           "pwsh": "if (($null -eq $script:calls) -or ($script:calls -ge 3)){$script:calls=0}; ++$script:calls; $script:calls",
           "go": "func() func() int { g := 0; return func() int { g++; return g } }()",
-          "erlang": "fun() -> G=case get(g) of undefined -> 1; _G -> _G end, put(g, G+1), G end."
+          "erlang": "fun() -> G=case get(g) of undefined -> 1; _G -> _G end, put(g, G+1), G end.",
+          "matlab": "@()feval(@(x,c)c, evalc('setenv(''COUNT'', string(lookup(dictionary(NaN,1,3,1), str2double(getenv(''COUNT'')), FallbackValue=str2double(getenv(''COUNT''))+1)))'), str2double(getenv('COUNT')))"
         }
       },
       "template": "{{lambda}} == {{{lambda}}} == {{lambda}}",
@@ -108,7 +112,8 @@
           "lisp": "(lambda () \">\")",
           "pwsh": "\">\"",
           "go": "func() string { return \">\" }",
-          "erlang": "fun() -> \">\" end."
+          "erlang": "fun() -> \">\" end.",
+          "matlab": "@() \">\""
         }
       },
       "template": "<{{lambda}}{{{lambda}}}",
@@ -131,7 +136,8 @@
           "lisp": "(lambda (text) (if (string= text \"{{x}}\") \"yes\" \"no\"))",
           "pwsh": "if ($args[0] -eq \"{{x}}\") {\"yes\"} else {\"no\"}",
           "go": "func(text string) string { if text == \"{{x}}\" { return \"yes\" } else { return \"no\" } }",
-          "erlang": "fun(\"{{x}}\") -> \"yes\"; (_) -> \"no\" end."
+          "erlang": "fun(\"{{x}}\") -> \"yes\"; (_) -> \"no\" end.",
+          "matlab": "@(text)lookup(dictionary(true, \"yes\"), text==\"{{x}}\", FallbackValue=\"no\")"
         }
       },
       "template": "<{{#lambda}}{{x}}{{/lambda}}>",
@@ -154,7 +160,8 @@
           "lisp": "(lambda (text) (format nil \"~a{{planet}}~a\" text text))",
           "pwsh": "\"$($args[0]){{planet}}$($args[0])\"",
           "go": "func(text string) string { return text + \"{{planet}}\" + text }",
-          "erlang": "fun(Text) -> Text ++ \"{{planet}}\" ++ Text end."
+          "erlang": "fun(Text) -> Text ++ \"{{planet}}\" ++ Text end.",
+          "matlab": "@(text) text + \"{{planet}}\" + text"
         }
       },
       "template": "<{{#lambda}}-{{/lambda}}>",
@@ -177,7 +184,8 @@
           "lisp": "(lambda (text) (format nil \"~a{{planet}} => |planet|~a\" text text))",
           "pwsh": "\"$($args[0]){{planet}} => |planet|$($args[0])\"",
           "go": "func(text string) string { return text + \"{{planet}} => |planet|\" + text }",
-          "erlang": "fun(Text) -> Text ++ \"{{planet}} => |planet|\" ++ Text end."
+          "erlang": "fun(Text) -> Text ++ \"{{planet}} => |planet|\" ++ Text end.",
+          "matlab": "@(text) text + \"{{planet}} => |planet|\" + text"
         }
       },
       "template": "{{= | | =}}<|#lambda|-|/lambda|>",
@@ -199,7 +207,8 @@
           "lisp": "(lambda (text) (format nil \"__~a__\" text))",
           "pwsh": "\"__$($args[0])__\"",
           "go": "func(text string) string { return \"__\" + text + \"__\" }",
-          "erlang": "fun(Text) -> \"__\" ++ Text ++ \"__\" end."
+          "erlang": "fun(Text) -> \"__\" ++ Text ++ \"__\" end.",
+          "matlab": "@(text)\"__\" + text + \"__\""
         }
       },
       "template": "{{#lambda}}FILE{{/lambda}} != {{#lambda}}LINE{{/lambda}}",
@@ -222,7 +231,8 @@
           "lisp": "(lambda (text) (declare (ignore text)) nil)",
           "pwsh": "$false",
           "go": "func(text string) bool { return false }",
-          "erlang": "fun(_) -> false end."
+          "erlang": "fun(_) -> false end.",
+          "matlab": "@() false"
         }
       },
       "template": "<{{^lambda}}{{static}}{{/lambda}}>",

--- a/specs/~lambdas.yml
+++ b/specs/~lambdas.yml
@@ -86,7 +86,7 @@ tests:
         pwsh:    'if (($null -eq $script:calls) -or ($script:calls -ge 3)){$script:calls=0}; ++$script:calls; $script:calls'
         go:      'func() func() int { g := 0; return func() int { g++; return g } }()'
         erlang:  'fun() -> G=case get(g) of undefined -> 1; _G -> _G end, put(g, G+1), G end.'
-        matlab:  "@() feval(@(~) getappdata(0, 'calls'), evalc('setappdata(0, ''calls'', mod(sum(getappdata(0, ''calls'')), 3) + 1)'))"
+        matlab:  '@() feval(@(~) getappdata(0, "calls"), evalc("setappdata(0, ""calls"", mod(sum(getappdata(0, ""calls"")), 3) + 1)"))'
     template: '{{lambda}} == {{{lambda}}} == {{lambda}}'
     expected: '1 == 2 == 3'
 

--- a/specs/~lambdas.yml
+++ b/specs/~lambdas.yml
@@ -27,6 +27,7 @@ tests:
         pwsh:    '"world"'
         go:      'func() string { return "world" }'
         erlang:  'fun() -> "world" end.'
+        matlab:  '@() "world"'
     template: "Hello, {{lambda}}!"
     expected: "Hello, world!"
 
@@ -46,6 +47,7 @@ tests:
         pwsh:    '"{{planet}}"'
         go:      'func() string { return "{{planet}}" }'
         erlang:  'fun() -> "{{planet}}" end.'
+        matlab:  '@() "{{planet}}"'
     template: "Hello, {{lambda}}!"
     expected: "Hello, world!"
 
@@ -65,6 +67,7 @@ tests:
         pwsh:    '"|planet| => {{planet}}"'
         go:      'func() string { return "|planet| => {{planet}}" }'
         erlang:  'fun() -> "|planet| => {{planet}}" end.'
+        matlab:  '@() "|planet| => {{planet}}"'
     template: "{{= | | =}}\nHello, (|&lambda|)!"
     expected: "Hello, (|planet| => world)!"
 
@@ -83,6 +86,7 @@ tests:
         pwsh:    'if (($null -eq $script:calls) -or ($script:calls -ge 3)){$script:calls=0}; ++$script:calls; $script:calls'
         go:      'func() func() int { g := 0; return func() int { g++; return g } }()'
         erlang:  'fun() -> G=case get(g) of undefined -> 1; _G -> _G end, put(g, G+1), G end.'
+        matlab:  "@() feval(@(~) getappdata(0, 'calls'), evalc('setappdata(0, ''calls'', mod(sum(getappdata(0, ''calls'')), 3) + 1)'))"
     template: '{{lambda}} == {{{lambda}}} == {{lambda}}'
     expected: '1 == 2 == 3'
 
@@ -101,6 +105,7 @@ tests:
         pwsh:    '">"'
         go:      'func() string { return ">" }'
         erlang:  'fun() -> ">" end.'
+        matlab:  '@() ">"'
     template: "<{{lambda}}{{{lambda}}}"
     expected: "<&gt;>"
 
@@ -120,6 +125,7 @@ tests:
         pwsh:    'if ($args[0] -eq "{{x}}") {"yes"} else {"no"}'
         go:      'func(text string) string { if text == "{{x}}" { return "yes" } else { return "no" } }'
         erlang:  'fun("{{x}}") -> "yes"; (_) -> "no" end.'
+        matlab:  '@(text) replace(string(text == "{{x}}"), ["false", "true"], ["no", "yes"])'
     template: "<{{#lambda}}{{x}}{{/lambda}}>"
     expected: "<yes>"
 
@@ -139,6 +145,7 @@ tests:
         pwsh:    '"$($args[0]){{planet}}$($args[0])"'
         go:      'func(text string) string { return text + "{{planet}}" + text }'
         erlang:  'fun(Text) -> Text ++ "{{planet}}" ++ Text end.'
+        matlab:  '@(text) text + "{{planet}}" + text'
     template: "<{{#lambda}}-{{/lambda}}>"
     expected: "<-Earth->"
 
@@ -158,6 +165,7 @@ tests:
         pwsh:    '"$($args[0]){{planet}} => |planet|$($args[0])"'
         go:      'func(text string) string { return text + "{{planet}} => |planet|" + text }'
         erlang:  'fun(Text) -> Text ++ "{{planet}} => |planet|" ++ Text end.'
+        matlab:  '@(text) text + "{{planet}} => |planet|" + text'
     template: "{{= | | =}}<|#lambda|-|/lambda|>"
     expected: "<-{{planet}} => Earth->"
 
@@ -176,6 +184,7 @@ tests:
         pwsh:    '"__$($args[0])__"'
         go:      'func(text string) string { return "__" + text + "__" }'
         erlang:  'fun(Text) -> "__" ++ Text ++ "__" end.'
+        matlab:  '@(text) "__" + text + "__"'
     template: '{{#lambda}}FILE{{/lambda}} != {{#lambda}}LINE{{/lambda}}'
     expected: '__FILE__ != __LINE__'
 
@@ -195,5 +204,6 @@ tests:
         pwsh:    '$false'
         go:      'func(text string) bool { return false }'
         erlang:  'fun(_) -> false end.'
+        matlab:  '@(~) false'
     template: "<{{^lambda}}{{static}}{{/lambda}}>"
     expected: "<>"


### PR DESCRIPTION
Add lambdas for MATLAB to ~lambdas.json and ~lambdas.yml.

The implementations are mostly straightforward, but I had to get a little creative for the "Section" and "Interpolation - Multiple Calls" tests because:
1. [Anonymous functions](https://www.mathworks.com/help/matlab/matlab_prog/anonymous-functions.html) that get evaluated and assigned to a variable cannot contain key words (`if`, `global`, etc.)
2. Anonymous functions must have static workspaces.

Users of a Mustache implementation written in MATLAB won't have to deal with either of these problems because they can write their lambda definitions in an .m file, but I wanted to keep the spec tests as standalone strings.