### PR TITLE
Fix "Standalone block" test.

### DIFF
--- a/specs/~inheritance.yml
+++ b/specs/~inheritance.yml
@@ -263,10 +263,11 @@ tests:
       parent: |
         Hi,
           {{$block}}{{/block}}
-    expected: |
+    expected: |-
       Hi,
         one
         two
+
   - name: Block reindentation
     desc: Block indentation is removed at the site of definition and added at the site of expansion
     data: {}

--- a/specs/~inheritance.yml
+++ b/specs/~inheritance.yml
@@ -267,7 +267,6 @@ tests:
       Hi,
         one
         two
-
   - name: Block reindentation
     desc: Block indentation is removed at the site of definition and added at the site of expansion
     data: {}


### PR DESCRIPTION
I'm currently reimplementing Mustache in Rust because the old crate is unmaintained. After some thorough testing, I believe that this test is contradictory to the expected result.

Currently, it expects the following output:
```
Hi,
  one
  two
```
Note the fact that the last line has a trailing newline.

However, the template for this test is as follows:
```
{{<parent}}{{$block}}
one
two{{/block}}
{{/parent}}
```
Note the fact that there is no newline in between the "two" and the closing tag.

And the parent looks like this:
```
Hi,
  {{$block}}{{/block}}
```
Because the block is a standalone tag, the specification says that the newline should be removed after it.

Therefore, I believe that the test should actually expect this, without a trailing newline:
```
Hi,
  one
  two⏎
```